### PR TITLE
SaraSchema Version 2

### DIFF
--- a/lib/sara-schema/version.rb
+++ b/lib/sara-schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SaraSchema
-  VERSION = '1.1.2'
+  VERSION = '2.0.0'
 end

--- a/schemas/assessment.json
+++ b/schemas/assessment.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://saraalert.mitre.org/assessment_schema.json",
+  "$id": "https://raw.githubusercontent.com/SaraAlert/sara-schema/master/schemas/assessment.json",
   "title": "Assessment",
   "description": "A patient asssessment root schema",
   "type": "object",
@@ -36,7 +36,7 @@
       ]
     },
     "experiencing_symptoms": {
-      "description": "Represents an assessment response over voice.",
+      "description": "Represents an assessment response over voice or SMS.",
       "type": ["boolean", "null"]
     },
     "reported_symptoms_array": {

--- a/schemas/assessment.json
+++ b/schemas/assessment.json
@@ -5,30 +5,43 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "response_status",
+    "error_code",
     "threshold_condition_hash",
+    "reported_symptoms_array",
+    "experiencing_symptoms",
     "patient_submission_token"
   ],
   "properties": {
+    "response_status": {
+      "description": "Twilio response status information and codes, if present",
+      "enum": [ "opt_out", "opt_in", "no_answer_voice", "no_answer_sms", "error_voice", "error_sms", "max_retries_sms", "max_retries_voice", "success_sms", "success_voice", null]
+    },
+    "error_code": {
+      "description": "A Twilio error code",
+      "type": ["null", "string"]
+    },
     "threshold_condition_hash": {
-      "type": "string",
       "description": "A way for an assessment to reference the set of symptoms and expected values that are associated with the assessment",
+      "type": ["string", "null"],
       "pattern": "[a-f0-9]{64}"
     },
     "patient_submission_token": {
-      "type": "string",
-      "description": "Unique token used to validate existence of a patient for this assessement's submission.",
-      "pattern": "[a-f0-9]{40}"
+      "description": "Unique token used to validate existence of a patient for this assessement's submission. Supports old 40 character token, new 10 character tokens, and 34 character execution flow IDs",
+      "type": ["string", "null"],
+      "anyOf": [
+        { "pattern": "^[a-f0-9]{40}$" },
+        { "pattern": "^[a-zA-Z0-9_-]{10}$" },
+        { "pattern": "^FN[a-f0-9]{32}$" }
+      ]
     },
     "experiencing_symptoms": {
       "description": "Represents an assessment response over voice.",
-      "anyOf": [
-        { "type": "boolean" },
-        { "type": "null" }
-      ]
+      "type": ["boolean", "null"]
     },
     "reported_symptoms_array": {
-      "type": "array",
       "description": "An array of symptoms and their values and types.",
+      "type": ["array", "null"],
       "minItems": 1,
       "items": {
         "type": "object",
@@ -47,11 +60,7 @@
           },
           "value": {
             "description": "The reported condition of the symptom from the patient",
-            "anyOf": [
-              { "type": "boolean" },
-              { "type": "number" },
-              { "type": "null" }
-            ]
+            "type": ["boolean", "number", "null"]
           },
           "type": {
             "description": "The internal application symptom type",
@@ -68,10 +77,7 @@
           },
           "notes": {
             "description": "Extended description of the symptom",
-            "anyOf": [
-              { "type": "string" },
-              { "type": "null" }
-            ]
+            "type": ["string", "null"]
           }
         }
       }

--- a/schemas/assessment.json
+++ b/schemas/assessment.json
@@ -51,7 +51,8 @@
           "value",
           "type",
           "label",
-          "notes"
+          "notes",
+          "required"
         ],
         "properties": {
           "name": {
@@ -78,6 +79,10 @@
           "notes": {
             "description": "Extended description of the symptom",
             "type": ["string", "null"]
+          },
+          "required": {
+            "description": "The symptom's importance when determining if an assessment is symptomatic",
+            "type": "boolean"
           }
         }
       }

--- a/schemas/assessment.json
+++ b/schemas/assessment.json
@@ -28,12 +28,7 @@
     },
     "patient_submission_token": {
       "description": "Unique token used to validate existence of a patient for this assessement's submission. Supports old 40 character token, new 10 character tokens, and 34 character execution flow IDs",
-      "type": ["string", "null"],
-      "anyOf": [
-        { "pattern": "^[a-f0-9]{40}$" },
-        { "pattern": "^[a-zA-Z0-9_-]{10}$" },
-        { "pattern": "^FN[a-f0-9]{32}$" }
-      ]
+      "type": ["string", "null"]
     },
     "experiencing_symptoms": {
       "description": "Represents an assessment response over voice or SMS.",

--- a/test/data_structures/schema/all_symptom_types_assessment.json
+++ b/test/data_structures/schema/all_symptom_types_assessment.json
@@ -1,5 +1,7 @@
 {
-  "threshold_condition_hash":"44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
+  "response_status": null,
+  "error_code": null,
+  "threshold_condition_hash": "44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
   "reported_symptoms_array": [
     {
       "name": "fever",
@@ -23,6 +25,6 @@
       "notes": null
     }
   ],
-  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b",
-  "experiencing_symptoms": true
+  "experiencing_symptoms": null,
+  "patient_submission_token": "379fc17f60bfba1933c2961ffc6a60e554a8347b"
 }

--- a/test/data_structures/schema/large_web_assessment.json
+++ b/test/data_structures/schema/large_web_assessment.json
@@ -1,5 +1,7 @@
 {
-  "threshold_condition_hash":"44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
+  "response_status": null,
+  "error_code": null,
+  "threshold_condition_hash": "44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
   "reported_symptoms_array": [
     {
       "name": "cough",
@@ -58,6 +60,6 @@
       "notes": null
     }
   ],
-  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b",
-  "experiencing_symptoms": true
+  "experiencing_symptoms": true,
+  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b"
 }

--- a/test/data_structures/schema/mobile_assessment.json
+++ b/test/data_structures/schema/mobile_assessment.json
@@ -1,5 +1,8 @@
 {
-  "threshold_condition_hash":"44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
-  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b",
-  "experiencing_symptoms": true
+  "response_status": "success_sms",
+  "error_code": null,
+  "threshold_condition_hash": "44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
+  "reported_symptoms_array": null,
+  "experiencing_symptoms": true,
+  "patient_submission_token": "0rb-AFVYEh"
 }

--- a/test/data_structures/schema/opt_out_assessment.json
+++ b/test/data_structures/schema/opt_out_assessment.json
@@ -1,8 +1,8 @@
 {
-  "response_status": null,
+  "response_status": "opt_out",
   "error_code": null,
   "threshold_condition_hash": null,
   "reported_symptoms_array": null,
   "experiencing_symptoms": null,
-  "patient_submission_token": null
+  "patient_submission_token": "FNf9193a1e62d1333a20a84ef183e751df"
 }

--- a/test/data_structures/schema/web_assessment.json
+++ b/test/data_structures/schema/web_assessment.json
@@ -1,4 +1,6 @@
 {
+  "response_status": null,
+  "error_code": null,
   "threshold_condition_hash":"44707d0e90fd17196ea91a6efc6b67106b59484eccb10b045c3794673e29c134",
   "reported_symptoms_array": [
     {
@@ -9,6 +11,6 @@
       "notes": "Feeling feverish or have a measured temperature at or above 100.4°F/38°C"
     }
   ],
-  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b",
-  "experiencing_symptoms": true
+  "experiencing_symptoms": null,
+  "patient_submission_token":"379fc17f60bfba1933c2961ffc6a60e554a8347b"
 }

--- a/test/jobs/assessment_test.rb
+++ b/test/jobs/assessment_test.rb
@@ -10,7 +10,7 @@ class AssessmentTest < Minitest::Test
   def test_valid
     @data_structures.each do |data_structure|
       data = JSON.parse(File.read(data_structure))
-      assert SaraSchema::Validator.validate(:assessment, data)
+      assert SaraSchema::Validator.validate(:assessment, data), data_structure
     end
   end
 


### PR DESCRIPTION
* Update base schema to draft-07 of json-schema.org
* Incorporates Twilio Errors into base schema through error_code schema
* Incorporates Execution IDs into patient_submission_token schema
* Incorporates recognized Twilio response status through response_status_schema
* Incorporates short and long-form patient submission tokens into patient_submission_token schema
* Allows all fields to be null
* Fixes various validation issues
* Expand test data structures with most common assessment types and edge cases
* Add missing properties to reported_symptoms_array schema